### PR TITLE
fix: blog page styles without js

### DIFF
--- a/components/Achievement.js
+++ b/components/Achievement.js
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
-import { CustomLink } from "../components/MDXComponents";
 import Flex from "../components/Flex";
 import Check from "../Icon/Check";
+import CustomLink from "./components/Link";
 
 const CheckCSS = css`
   margin-right: 0.5rem;

--- a/components/Introduction.js
+++ b/components/Introduction.js
@@ -2,7 +2,7 @@ import React from "react";
 import Socials from "./Socials";
 import Flex from "../components/Flex";
 import styled from "styled-components";
-import { CustomLink } from "./MDXComponents";
+import CustomLink from "./components/Link";
 
 const Introduction = () => {
   return (

--- a/components/MDXComponents/index.js
+++ b/components/MDXComponents/index.js
@@ -1,6 +1,5 @@
-import NextLink from "next/link";
 import styled, { css } from "styled-components";
-import Flex from "../../components/Flex";
+import CustomLink from "../components/Link";
 
 // const Quote = (props) => {
 //   return (
@@ -23,66 +22,9 @@ import Flex from "../../components/Flex";
 
 const Table = (props) => (
   <div style={{ overflowX: "auto", width: "100%" }}>
-    <table
-      style={{ textAlign: "left", marginBottom: "32px", width: "100%" }}
-      {...props}
-    />
+    <table {...props} />
   </div>
 );
-
-const THead = styled.th`
-  background: #3c3e43;
-  font-weight: 400;
-  padding: 0.5rem;
-  font-size: 1.2rem;
-`;
-
-const TData = styled.td`
-  padding: 0.5rem;
-  border-bottom-width: 1px;
-  border-color: "inherit";
-  font-size: 1rem;
-  white-space: normal;
-`;
-
-const CustomLink = (props) => {
-  const href = props.href;
-  const isInternalLink = href && (href.startsWith("/") || href.startsWith("#"));
-
-  if (isInternalLink) {
-    return (
-      <NextLink href={href} passHref>
-        <Link {...props} />
-      </NextLink>
-    );
-  }
-
-  return <Link target="_blank" {...props} rel="noopener" />;
-};
-
-const Link = styled.a`
-  cursor: pointer;
-  text-decoration: none;
-  outline: none;
-  color: #60b3fb;
-
-  :hover {
-    color: #ed7842;
-    transition: all 0.15s ease-out;
-  }
-`;
-
-const HeadingCSS = css`
-  scroll-snap-align: start;
-  scroll-margin-top: 6rem;
-  padding-bottom: 0.5rem;
-  padding-top: 1rem;
-  color: #fefefe;
-
-  &[id]:hover > a {
-    display: inline;
-  }
-`;
 
 const DocsHeading = (props) => {
   if (!props.id) return null;
@@ -105,111 +47,53 @@ const HashSelector = styled.a`
   display: none;
 `;
 
-const Divider = styled.div`
-  width: 100%;
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-  border-bottom: 0.006rem solid #aeb0b7;
-  opacity: 0.6;
-`;
-
-const Heading1 = styled.h1`
-  ${HeadingCSS}
-  font-size: 2rem;
-`;
-
-const Heading2 = styled.h2`
-  ${HeadingCSS}
-  font-size: 1.5rem;
-`;
-
-const Heading3 = styled.h3`
-  ${HeadingCSS}
-  font-size: 1.2rem;
-`;
-
-const listItemCSS = css`
-  list-style: auto;
-  padding-bottom: 1rem;
-  padding-left: 1rem;
-  margin-left: 0.5rem;
-`;
-
-const P = styled.p`
-  padding-bottom: 1.4rem;
-  line-height: 1.625;
-`;
-
-const OL = styled.ol`
-  ${listItemCSS}
-`;
-
-const UL = styled.ul`
-  ${listItemCSS}
-`;
-
 const MDXComponents = {
   h1: (props) => {
     const { children, ...rest } = props;
     return (
-      <Heading1 id={children.replaceAll(" ", "-")} {...rest}>
+      <h1 id={children.replaceAll(" ", "-")} {...rest}>
         {children}
         <DocsHeading id={children.replaceAll(" ", "-")} />
-      </Heading1>
+      </h1>
     );
   },
   h2: (props) => {
     const { children, ...rest } = props;
     return (
-      <Heading2 id={children.replaceAll(" ", "-")} {...rest}>
+      <h2 id={children.replaceAll(" ", "-")} {...rest}>
         {children}
         <DocsHeading id={children.replaceAll(" ", "-")} />
-      </Heading2>
+      </h2>
     );
   },
   h3: (props) => {
     const { children, ...rest } = props;
     return (
-      <Heading3 id={children.replaceAll(" ", "-")} {...rest}>
+      <h3 id={children.replaceAll(" ", "-")} {...rest}>
         {children}
         <DocsHeading id={children.replaceAll(" ", "-")} />
-      </Heading3>
+      </h3>
     );
   },
-  inlineCode: (props) => (
-    <code
-      style={{
-        color: "rgb(255 139 139)",
-        backgroundColor: "#202124",
-        padding: "0.25rem",
-        borderRadius: "2px",
-        fontSize: "0.84em",
-        marginRight: "0.25rem",
-        marginLeft: "0.25rem",
-        border: "1px solid rgb(52 52 55)",
-      }}
-      {...props}
-    />
-  ),
+  inlineCode: (props) => <code {...props} />,
   br: (props) => <div style={{ height: "24px" }} {...props} />,
-  hr: Divider,
+  hr: (props) => <hr {...props} />,
   table: Table,
-  th: THead,
-  td: TData,
+  th: (props) => <th {...props} />,
+  td: (props) => <td {...props} />,
   a: CustomLink,
   p: (props) => {
-    return <P {...props} />;
+    return <p {...props} />;
   },
   ul: (props) => {
-    return <UL {...props} />;
+    return <ul {...props} />;
   },
   ol: (props) => {
-    return <OL {...props} />;
+    return <ol {...props} />;
   },
   li: (props) => {
-    return <li style={{ paddingBottom: "0.25rem" }} {...props} />;
+    return <li {...props} />;
   },
 };
 
-export { CustomLink };
 export default MDXComponents;

--- a/components/MDXComponents/styles.js
+++ b/components/MDXComponents/styles.js
@@ -1,0 +1,139 @@
+import styled, { css } from "styled-components";
+
+const Table = css`
+  .content-wrapper table {
+    text-align: left;
+    margin-bottom: 32px;
+    width: 100%;
+  }
+`;
+
+const THead = css`
+  .content-wrapper th {
+    background: #3c3e43;
+    font-weight: 400;
+    padding: 0.5rem;
+    font-size: 1.2rem;
+  }
+`;
+
+const TData = css`
+  .content-wrapper td {
+    padding: 0.5rem;
+    border-bottom-width: 1px;
+    border-color: "inherit";
+    font-size: 1rem;
+    white-space: normal;
+  }
+`;
+
+const BaseHeading = css`
+  scroll-snap-align: start;
+  scroll-margin-top: 6rem;
+  padding-bottom: 0.5rem;
+  padding-top: 1rem;
+  color: #fefefe;
+
+  &[id]:hover > a {
+    display: inline;
+  }
+`;
+
+const Heading1 = css`
+  .content-wrapper h1 {
+    ${BaseHeading}
+    font-size: 2.25rem;
+    line-height: 2.5rem;
+  }
+`;
+
+const Heading2 = css`
+  .content-wrapper h2 {
+    ${BaseHeading}
+    font-size: 1.875rem;
+    line-height: 2.25rem;
+  }
+`;
+
+const Heading3 = css`
+  .content-wrapper h3 {
+    ${BaseHeading}
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+  }
+`;
+
+const P = css`
+  .content-wrapper p {
+    padding-bottom: 1.4rem;
+    line-height: 1.625;
+  }
+`;
+
+const listItemCSS = css`
+  list-style: auto;
+  padding-bottom: 1rem;
+  padding-left: 1rem;
+  margin-left: 0.5rem;
+`;
+
+const OL = css`
+  .content-wrapper ol {
+    ${listItemCSS}
+  }
+`;
+
+const UL = css`
+  .content-wrapper ul {
+    ${listItemCSS}
+  }
+`;
+
+const LI = css`
+  .content-wrapper li {
+    padding-bottom: 0.5rem;
+    padding-left: 0.5rem;
+    margin-left: 0.5rem;
+  }
+`;
+
+const InlineCode = css`
+  .content-wrapper p > code {
+    color: rgb(255 139 139);
+    background-color: #202124;
+    padding: 0.25rem;
+    border-radius: 2px;
+    font-size: 0.84em;
+    margin-right: 0.25rem;
+    margin-left: 0.25rem;
+    border: 1px solid rgb(52 52 55);
+  }
+`;
+
+const HR = css`
+  .content-wrapper hr {
+    border-top-width: 0;
+    width: 100%;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    border-bottom: 0.006rem solid #aeb0b7;
+    opacity: 0.6;
+  }
+`;
+
+const Article = styled.article`
+  ${Table}
+  ${THead}
+  ${TData}
+  ${Heading1}
+  ${Heading2}
+  ${Heading3}
+  ${P}
+  ${OL}
+  ${UL}
+  ${LI}
+  ${InlineCode}
+  ${HR}
+`;
+
+export default Article;

--- a/components/components/Link.js
+++ b/components/components/Link.js
@@ -1,0 +1,31 @@
+import styled from "styled-components";
+import NextLink from "next/link";
+
+const CustomLink = (props) => {
+  const href = props.href;
+  const isInternalLink = href && (href.startsWith("/") || href.startsWith("#"));
+
+  if (isInternalLink) {
+    return (
+      <NextLink href={href} passHref>
+        <Link {...props} />
+      </NextLink>
+    );
+  }
+
+  return <Link target="_blank" {...props} rel="noopener" />;
+};
+
+const Link = styled.a`
+  cursor: pointer;
+  text-decoration: none;
+  outline: none;
+  color: #60b3fb;
+
+  :hover {
+    color: #ed7842;
+    transition: all 0.15s ease-out;
+  }
+`;
+
+export default CustomLink;

--- a/content/blog/notes-on-axel-rauschmayer-javascript-for-impatient-programmers.mdx
+++ b/content/blog/notes-on-axel-rauschmayer-javascript-for-impatient-programmers.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Notes on Axel Rauschmayer's JavaScript for Impatient Programmers"
 publishedAt: "2021-02-08"
-modifiedAt: "2021-02-08"
+modifiedAt: "2022-12-09"
 summary: "Notes on Axel Rauschmayer's JavaScript for Impatient Programmers. Suitable for interview preparation and quick revision of concepts."
 image: "/static/images/notes-on-axel-rauschmayer-javascript-for-impatient-programmers/banner.png"
 ---
@@ -33,7 +33,7 @@ console.log(i) //ReferenceError
 ```
 
 ### const
-Variables declared using const are blocked scoped and immutable. They have to be declared and uninitialised at the same point.
+Variables declared using const are blocked scoped and immutable. They have to be declared and uninitialized at the same point.
 ```js
 {
     const i = 0;
@@ -70,7 +70,7 @@ There are two types of global variables.
 2. Global object variables.
 	Variables are declared using `var` or `function` declarations.
 
-__globalThis__ is used to access global object variables. The reason why it got its name is because it is equal to `this` in the global scope.
+__globalThis__ is used to access global object variables. The reason why it got its name is that it is equal to `this` in the global scope.
 
 <CustomImage
     alt={`Global Scope`}
@@ -103,7 +103,7 @@ But, their activation is somewhere else. The activation is the line where we can
     const sum = 0;
 }
 ```
-Here we are trying to access a variable in its scope but the variable is not activated yet. `const`, `let` and `class` declarations behave in this particular way. The zone between the scope and activation of entity is called __Temporal Dead Zone__ (TDZ).  
+Here we are trying to access a variable in its scope but the variable is not activated yet. `const`, `let` and `class` declarations behave in this particular way. The zone between the scope and activation of the entity is called __Temporal Dead Zone__ (TDZ).  
 
 The reason why `class` declarations also have TDZ is following
 ```js
@@ -124,7 +124,7 @@ const onetwothree = () => {return 123;}
 ```
 
 ### Closures
-Closures are functions that have connection with variables that exists at its "_birth place_".
+Closures are functions that have a connection with variables that exist at their "_birth place_".
 ```js
 function increment(value){
 	return (num) => {
@@ -147,11 +147,11 @@ __Use cases of closures__
 __What is a type?__
 
 Type is a set of values. 
-For example, type `boolean` consist of `{true,false}`. Only two values.
+For example, type `boolean` consist of `{true, false}`. Only two values.
 
 Similarly, `string` and `number` have infinitely many values.
 
-The types in JS
+The types in JS are:
 - null
 - undefined
 - boolean
@@ -163,9 +163,7 @@ The types in JS
 
 __Primitive values__ are variables of the types null, undefined, string, number, bigint, symbol and boolean and all other values are __objects__.
 
-Primitive values are always __passed and compared by values__.
-
-Object values are always __passed and compared by reference__.
+Primitive values are always __passed and compared by values__. Object values are always __passed and compared by reference__.
 
 Two common ways of creating an object:
 

--- a/pages/blog/[slug].js
+++ b/pages/blog/[slug].js
@@ -4,12 +4,13 @@ import matter from "gray-matter";
 import fs from "fs";
 import path from "path";
 import BlogHeader from "../../components/BlogHeader";
-import { CustomLink } from "../../components/MDXComponents";
 import mdxPrism from "mdx-prism";
 import BlogSeo from "../../components/BlogSeo";
 import CustomImage from "../../components/CustomImage";
 import styled from "styled-components";
 import { FiArrowLeft } from "react-icons/fi";
+import Article from "../../components/MDXComponents/styles";
+import CustomLink from "../../components/components/Link";
 
 const root = process.cwd();
 
@@ -36,11 +37,11 @@ export default function BlogPost({ mdxSource, frontMatter, slug }) {
           <span>Back to Blog</span>
         </BackToBlog>
 
-        <article>
+        <Article>
           <header>
             <BlogHeader frontMatter={frontMatter} slug={slug} />
           </header>
-          <Content>{content}</Content>
+          <Content className="content-wrapper">{content}</Content>
           <footer>
             <EditLinks>
               <CustomLink href={discussUrl(slug)} isExternal>
@@ -52,7 +53,7 @@ export default function BlogPost({ mdxSource, frontMatter, slug }) {
               </CustomLink>
             </EditLinks>
           </footer>
-        </article>
+        </Article>
       </Main>
     </>
   );


### PR DESCRIPTION
use css to target elements on `/blog/:id` page, and removes the initial ugly content while JS is being downloaded.

